### PR TITLE
Alternate zones

### DIFF
--- a/AvalancheAPI.php
+++ b/AvalancheAPI.php
@@ -33,7 +33,6 @@ class AvalancheAPI
         $this->tableBaseUrl = (isset($config['station_group_tables'])) ? $config['station_group_tables'] : $apiDefaults['station_group_tables'];
         $this->groupTablesConfig = (isset($config['station_group_tables_config'])) ? $config['station_group_tables_config'] : $apiDefaults['station_group_tables_config'];
         $this->externalModalLinks = (isset($config['custom_external_modal_links'])) ? $config['custom_external_modal_links'] : $apiDefaults['custom_external_modal_links'];
-        $this->externalModalLinks = (isset($config['custom_external_modal_links'])) ? $config['custom_external_modal_links'] : $apiDefaults['custom_external_modal_links'];
         $this->wxMapZones = (isset($config['wx_map_zones'])) ? $config['wx_map_zones'] : $apiDefaults['wx_map_zones'];
     }
 

--- a/AvalancheAPI.php
+++ b/AvalancheAPI.php
@@ -20,8 +20,8 @@ class AvalancheAPI
             "wx_maps" => "https://cdn.snowobs.com/nac-prod",
             "station_group_tables" => "https://cdn.snowobs.com/group-tables-prod",
             "station_group_tables_config" => false,
-            "custom_external_modal_links" => false
-            "wx_map_config" => false
+            "custom_external_modal_links" => false,
+            "wx_map_zones" => false
         ];
 
         $config = require __DIR__ . '/config.php';

--- a/AvalancheAPI.php
+++ b/AvalancheAPI.php
@@ -21,6 +21,7 @@ class AvalancheAPI
             "station_group_tables" => "https://cdn.snowobs.com/group-tables-prod",
             "station_group_tables_config" => false,
             "custom_external_modal_links" => false
+            "wx_map_config" => false
         ];
 
         $config = require __DIR__ . '/config.php';
@@ -32,6 +33,8 @@ class AvalancheAPI
         $this->tableBaseUrl = (isset($config['station_group_tables'])) ? $config['station_group_tables'] : $apiDefaults['station_group_tables'];
         $this->groupTablesConfig = (isset($config['station_group_tables_config'])) ? $config['station_group_tables_config'] : $apiDefaults['station_group_tables_config'];
         $this->externalModalLinks = (isset($config['custom_external_modal_links'])) ? $config['custom_external_modal_links'] : $apiDefaults['custom_external_modal_links'];
+        $this->externalModalLinks = (isset($config['custom_external_modal_links'])) ? $config['custom_external_modal_links'] : $apiDefaults['custom_external_modal_links'];
+        $this->wxMapZones = (isset($config['wx_map_zones'])) ? $config['wx_map_zones'] : $apiDefaults['wx_map_zones'];
     }
 
     /**
@@ -133,6 +136,7 @@ class AvalancheAPI
                 'center_id' => $this->centerID,
                 'token' => $this->token,
                 'wx_base_url' => $this->wxBaseUrl,
+                'wx_map_zones' -> $this->wxMapZones,
                 'external_modal_links' => $this->externalModalLinks
             ]
         );

--- a/AvalancheAPI.php
+++ b/AvalancheAPI.php
@@ -136,7 +136,7 @@ class AvalancheAPI
                 'center_id' => $this->centerID,
                 'token' => $this->token,
                 'wx_base_url' => $this->wxBaseUrl,
-                'wx_map_zones' -> $this->wxMapZones,
+                'wx_map_zones' => $this->wxMapZones,
                 'external_modal_links' => $this->externalModalLinks
             ]
         );

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ The following configuration options are modified in the configuration file `conf
   - Defaults to the production weather maps to be used on public facing website
   - Changing allows testing of features in development, coordinate with National Avalanche Center to change
 - **`wx_map_zones`**, *Optional*
-  - Url to a publicly accessable kml file that defines alternate polygons for table grouping
+  - Url to a publicly accessible kml file that defines alternate polygons for table grouping
   - Group title and order is controlled by polygon name and order in kml file
 - **`custom_external_modal_links`**, *Optional*
-  - Allows custom links to be disaplyed inside the station modal
+  - Allows custom links to be displayed inside the station modal
   - Will open links in new window
 
 ## Map setup

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # avalanche.org-API-Client
+
 A client to interact with the avalanche.org API.
 
 Current functionality includes:
+
 - [Forecast map](#forecast-map) - your avalanche center region with zones and danger ratings
 - [Weather map](#weather-map) - weather station map, table, time series
 - [Grouped weather table](#grouped-weather-table) - showing multiple weather stations in a single table
-
 
 ## Requirements
 
@@ -26,7 +27,6 @@ return [
 ];
 ```
 
-
 # Forecast map
 
 ## Default usage
@@ -43,7 +43,7 @@ $map = $api->getMap();
 
 ```html
 <!-- Now echo $map variable into the containing div in which the map should be displayed -->
-<div class='map-div'><?= $map; ?></div>
+<div class="map-div"><?= $map; ?></div>
 ```
 
 ## Optional customizations
@@ -69,6 +69,7 @@ $map = $api->getMap([
 - map_height: number, in pixels
 
 ## Updating your forecast
+
 Note: you must have already coordinated with avalanche.org and setup the necessary data sharing files in order for this to work.
 
 ```php
@@ -88,6 +89,7 @@ The remote weather station map displays weather station data for the forecast ar
 **Note**: you must have already coordinated with the National Avalanche Center to obtain access to the weather maps API and received a token.
 
 ## Configuration
+
 The following configuration options are modified in the configuration file `config.php` for the `avalanche.org-API-Client`.
 
 ```php
@@ -110,13 +112,13 @@ The following configuration options are modified in the configuration file `conf
   - By default, the weather table will group stations by the forecast zone boundaries
 - **`token`**
   - Weather maps token obtained from the National Avalanche Center
-- **`wx_maps`**, *Optional*
+- **`wx_maps`**, _Optional_
   - Defaults to the production weather maps to be used on public facing website
   - Changing allows testing of features in development, coordinate with National Avalanche Center to change
-- **`wx_map_zones`**, *Optional*
+- **`wx_map_zones`**, _Optional_
   - Url to a publicly accessible kml file that defines alternate polygons for table grouping
   - Group title and order is controlled by polygon name and order in kml file
-- **`custom_external_modal_links`**, *Optional*
+- **`custom_external_modal_links`**, _Optional_
   - Allows custom links to be displayed inside the station modal
   - Will open links in new window
 
@@ -138,9 +140,16 @@ To setup the map, login to [avalanche.org](https://avalanche.org/) and go to the
   - Inline editing of `Long Name`, `Tab` and `Rounding` are available
   - `Show Variable`, controls the what variables are shown, if green will show the variable on the map, if red will not show this variable
   - Submit will submit the table and save changes
-
+- **Webcams**
+  - Right click on the map to place a webcam
+  - Left click on the new (or existing) webcam to bring up the webcam form modal
+  - Provide a title to the webcam which will show on hover
+  - The "Image Information" card is the name and image url for the webcam
+  - "Add Another Image" will add additional webcam images to the modal
+  - Click "Save Webcam" to save or "Delete Webcam" to delete
 
 ## Usage
+
 If the map has not been setup on [avalanche.org](https://avalanche.org/), it will default to the SNFAC forecast zone until the map has been properly configured for a particular avalanche center.
 
 ```php
@@ -154,10 +163,10 @@ $wxMap = $api->getWeatherMap();
 
 ```html
 <!-- Now echo $wxMap variable into the containing div in which the map should be displayed -->
-<div class='map-div'><?= $wxMap; ?></div>
+<div class="map-div"><?= $wxMap; ?></div>
 
 <!-- or -->
-<div class='map-div'><?= echo $wxMap; ?></div>
+<div class="map-div"><?= echo $wxMap; ?></div>
 ```
 
 # Grouped weather table
@@ -165,6 +174,7 @@ $wxMap = $api->getWeatherMap();
 **Note**: you must have already coordinated with the National Avalanche Center to obtain access to the weather maps API and received a token.
 
 ## Configuration
+
 If weather station grouping is desired, put the following configuration in the configuration file `config.php` for the `avalanche.org-API-Client`.
 
 ```php
@@ -198,6 +208,5 @@ $wxTable = $api->getGroupTables({table_name});
 
 ```html
 <!-- Now echo $wxTable variable into the containing div in which the table should be displayed -->
-<div class='table-div'><?= $wxTable; ?></div>
-
+<div class="table-div"><?= $wxTable; ?></div>
 ```

--- a/README.md
+++ b/README.md
@@ -6,26 +6,23 @@ Current functionality includes:
 - [Weather map](#weather-map) - weather station map, table, time series
 - [Grouped weather table](#grouped-weather-table) - showing multiple weather stations in a single table
 
-## Configuration
+# Configuration
 
-Create a configuration file in the root of this project directory, called `config.php`. It should contain the following (contact the National Avalanche Center for token access)
+Create a configuration file in the root of this project directory, called `config.php`. It should contain, at a minimum, the avalanche center ID.
 
 ```php
 <?php
 
 return [
-    //Avalanche Center ID
-    'center_id' => 'SNFAC',
-    //Weather maps token
-    'token' => 'your-weather-maps-token'
+    // Avalanche Center ID
+    'center_id' => 'SNFAC'
 ];
-
 ```
 
 
-## Forecast map
+# Forecast map
 
-#### Default usage
+## Default usage
 
 ```php
 <?php
@@ -35,16 +32,14 @@ require_once 'avalanche.org-API-Client/AvalancheAPI.php';
 //Create and load map
 $api = new AvalancheAPI();
 $map = $api->getMap();
-
 ```
 
 ```html
 <!-- Now echo $map variable into the containing div in which the map should be displayed -->
 <div class='map-div'><?= $map; ?></div>
-
 ```
 
-#### Optional customizations
+## Optional customizations
 
 ```php
 <?php
@@ -59,7 +54,6 @@ $map = $api->getMap([
     "danger_scale" => "bottom",
     "map_height" => 400
 ]);
-
 ```
 
 - basemap_color: bw, lightColor, color
@@ -67,7 +61,7 @@ $map = $api->getMap([
 - danger_scale: bottom, top
 - map_height: number, in pixels
 
-#### Updating your forecast
+## Updating your forecast
 Note: you must have already coordinated with avalanche.org and setup the necessary data sharing files in order for this to work.
 
 ```php
@@ -80,9 +74,67 @@ $api->updateForecast();
 
 ```
 
-## Weather Map
+# Weather Map
 
-Note: you must have already coordinated with the National Avalanche Center to obtain access to the weather maps API and received a token.
+The remote weather station map displays weather station data for the forecast area using a map, table and modal to display the station timeseries.
+
+**Note**: you must have already coordinated with the National Avalanche Center to obtain access to the weather maps API and received a token.
+
+## Configuration
+The following configuration options are modified in the configuration file `config.php` for the `avalanche.org-API-Client`.
+
+```php
+<?php
+...
+'center_id' => '<center-id>',
+'token' => '<weather-map-token>',
+'wx_maps' => '<optional>',
+'wx_map_zones' => '<optional-url-to-kml-file>',
+'custom_external_modal_links' => [
+  '<station-id>' => [
+    '<link-name>' => '<link>'
+  ]
+]
+...
+```
+
+- **`center_id`**
+  - Avalanche Center ID to display the forecast zone boundaries.
+  - By default, the weather table will group stations by the forecast zone boundaries
+- **`token`**
+  - Weather maps token obtained from the National Avalanche Center
+- **`wx_maps`**, *Optional*
+  - Defaults to the production weather maps to be used on public facing website
+  - Changing allows testing of features in development, coordinate with National Avalanche Center to change
+- **`wx_map_zones`**, *Optional*
+  - Url to a publicly accessable kml file that defines alternate polygons for table grouping
+  - Group title and order is controlled by polygon name and order in kml file
+- **`custom_external_modal_links`**, *Optional*
+  - Allows custom links to be disaplyed inside the station modal
+  - Will open links in new window
+
+## Map setup
+
+To setup the map, login to [avalanche.org](https://avalanche.org/) and go to the weather map setup page. The following is a short description of the setup features, see the documentation for full setup instructions.
+
+- **Adding a station**: Single click on a station, a white halo will indicate that the station has been added
+- **Removing a station**: Single click on a station that has a white halo
+- **Map menu**
+  - Submit button will submit the map settings below and set the center of the map at the current view
+  - Re-center button will recenter the map to the default view
+  - Change the Avalanche Center for the zone boundaries
+  - Default map zoom
+  - Data sources, NWAC sources is only for NWAC stations and are not available outside the NWAC forecast area
+  - Map settings to customize units, timezone, current measurements and QC from Mesowest
+- **Varible control**
+  - Table view button shows a table of all the variables from Mesowest and Snotel
+  - Inline editing of `Long Name`, `Tab` and `Rounding` are available
+  - `Show Variable`, controls the what variables are shown, if green will show the variable on the map, if red will not show this variable
+  - Submit will submit the table and save changes
+
+
+## Usage
+If the map has not been setup on [avalanche.org](https://avalanche.org/), it will default to the SNFAC forecast zone until the map has been properly configured for a particular avalanche center.
 
 ```php
 <?php
@@ -91,20 +143,21 @@ require_once 'avalanche.org-API-Client/AvalancheAPI.php';
 $api = new AvalancheAPI();
 //Get the weather maps view, then echo where desired
 $wxMap = $api->getWeatherMap();
-
 ```
 
 ```html
 <!-- Now echo $wxMap variable into the containing div in which the map should be displayed -->
 <div class='map-div'><?= $wxMap; ?></div>
 
+<!-- or -->
+<div class='map-div'><?= echo $wxMap; ?></div>
 ```
 
-## Grouped weather table
+# Grouped weather table
 
-Note: you must have already coordinated with the National Avalanche Center to obtain access to the weather maps API and received a token.
+**Note**: you must have already coordinated with the National Avalanche Center to obtain access to the weather maps API and received a token.
 
-### Configuration
+## Configuration
 If weather station grouping is desired, put the following configuration in the configuration file `config.php` for the `avalanche.org-API-Client`.
 
 ```php
@@ -122,7 +175,7 @@ If weather station grouping is desired, put the following configuration in the c
 
 The `{table_name}` will become the header for the table. The `{station_id_XX}` is the station id, either the Mesowest station code or custom data stream id. The `{variable}` is the standardized variable name to display in the table. The order of the station/variable pair will dictate the column order in the table.
 
-### Usage
+## Usage
 
 Each `{table_name}` in the configuration can be placed in their own webpage.
 

--- a/views/weather_map.php
+++ b/views/weather_map.php
@@ -32,8 +32,9 @@
 <script type='text/javascript'>
 
     const token = "<?= $params['token']; ?>";
-		const config = <?= json_encode($params); ?>;
+    const config = <?= json_encode($params); ?>;
     var map;
+    
     window.onload = function () {
         map = new soMap();
         map.buildMap(token, false, config);


### PR DESCRIPTION
This is an expansion of PR #9 where @ccorey added the `wx_map_zones` to the API client. This has been tested with the weather maps to ensure that the kml file provided can be parsed and used to group the weather stations. The README has been updated to add more documentation on the weather maps.

To use this feature, supply the `wx_map_zones`  that points to a url of a publicly accessible kml file. The file should consist of multiple polygons, where the name and order will dictate the displayed name and order in the weather map table. The weather maps will load this file in and group the station table. 